### PR TITLE
Update log4j 2.17.0 to 2.17.1

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.0</version>
+			<version>2.17.1</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Please refer to these articles below.

- https://snyk.io/blog/new-log4j-2-17-1-fixes-cve-2021-44832-remote-code-execution-but-its-not-as-bad-as-it-sounds/

- https://securityaffairs.co/wordpress/126135/hacking/new-apache-log4j-cve-2021-44832.html